### PR TITLE
Improve support for Unlimited plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Thumbs.db
+.DS_Store

--- a/extension/html/browserActionPopup.html
+++ b/extension/html/browserActionPopup.html
@@ -25,7 +25,7 @@
 							<td><span class="tooltip" title="Regular data used that counts towards your monthly cap">Data used:</span></td>
 							<td id="dataUsed">?? GB</td>
 						</tr>
-						<tr class="data">
+						<tr class="data unlimited-hide">
 							<td><span class="tooltip" title="Data limit - Data used">Data remaining:</span></td>
 							<td id="dataRemaining">?? GB</td>
 						</tr>
@@ -49,11 +49,11 @@ This data does not count towards your monthly cap and is not part of the calcula
 							<td><span class="tooltip" title="Average daily usage &times; Days in billing period">Billing period estimate:</span></td>
 							<td id="monthlyEstimate">?? GB</td>
 						</tr>
-						<tr class="estimates">
+						<tr class="estimates unlimited-hide">
 							<td><span class="tooltip" title="Data remaining &divide; Days remaining">Suggested daily usage:</span></td>
 							<td id="suggestedDailyUsage">?? GB</td>
 						</tr>
-						<tr class="addWhiteSpaceBelow">
+						<tr class="addWhiteSpaceBelow unlimited-hide">
 							<td colspan="2" style="padding-right:0">
 								<div id="percentageBar"><img id="notch" src="/img/notch.png" /><div id="unfilledPortion"></div></div>
 							</td>

--- a/extension/html/browserActionPopup.html
+++ b/extension/html/browserActionPopup.html
@@ -25,7 +25,7 @@
 							<td><span class="tooltip" title="Regular data used that counts towards your monthly cap">Data used:</span></td>
 							<td id="dataUsed">?? GB</td>
 						</tr>
-						<tr class="data unlimited-hide">
+						<tr class="data">
 							<td><span class="tooltip" title="Data limit - Data used">Data remaining:</span></td>
 							<td id="dataRemaining">?? GB</td>
 						</tr>
@@ -49,11 +49,11 @@ This data does not count towards your monthly cap and is not part of the calcula
 							<td><span class="tooltip" title="Average daily usage &times; Days in billing period">Billing period estimate:</span></td>
 							<td id="monthlyEstimate">?? GB</td>
 						</tr>
-						<tr class="estimates unlimited-hide">
+						<tr class="estimates">
 							<td><span class="tooltip" title="Data remaining &divide; Days remaining">Suggested daily usage:</span></td>
 							<td id="suggestedDailyUsage">?? GB</td>
 						</tr>
-						<tr class="addWhiteSpaceBelow unlimited-hide">
+						<tr class="addWhiteSpaceBelow">
 							<td colspan="2" style="padding-right:0">
 								<div id="percentageBar"><img id="notch" src="/img/notch.png" /><div id="unfilledPortion"></div></div>
 							</td>

--- a/extension/scripts/backgroundEventPage.js
+++ b/extension/scripts/backgroundEventPage.js
@@ -180,24 +180,40 @@ function fetchDataUsage () {
 				} else if ($('h2:contains("Data Services")', result).length != 1) {
 					console.warn('Oops! Snap Usage Monitor logged into your account okay, but no Data Services were found.');
 				} else {
-					// Logged in successfully!
-					// Parse the fetched HTML
+					// Logged in successfully! Parse the fetched HTML
 					var tableRow = $('div.service tbody tr', result).first();
-					var cell_0 = $('td', tableRow).first();
-					var planName = $('a', cell_0).text();
-					var billingPeriodDates = $('span', cell_0).text().split('-');
+					
+					// Plan details
+					var planCell = $('td', tableRow).eq(0);
+					var planName = $('a', planCell).text();
+					var billingPeriodDates = $('span', planCell).text().split('-');
 					var billingPeriodStartDate = $.trim(billingPeriodDates[0]);
 					var billingPeriodEndDate = $.trim(billingPeriodDates[1]);
-					var gigabyteLimit = $('td', tableRow).last().text().split(' ')[0];
-					var gigabytesRemaining;
-					var remainingCell = $('td', tableRow).last().prev();
-					var remainingNumbers = remainingCell.text().split(' ')[0];
-					// Remaining data cell is normally in GB
-					if (substr_count(remainingCell.text(), 'GB') == 1) {
-						gigabytesRemaining = remainingNumbers;
-					// But if there's less than 1 GB remaining, data is displayed in MB
+					
+					// Used
+					var usedCell = $('td', tableRow).eq(1).text().split(' ');
+					if(usedCell[1] == 'GB') {
+						usedGB = usedCell[0];
 					} else {
-						gigabytesRemaining = remainingNumbers / 1024;
+						usedGB = usedCell[0] / 1024;
+					}
+					
+					// Remaining
+					var remainingCell = $('td', tableRow).eq(2).text().split(' ');
+					if(remainingCell[0] == 'N/A') {
+						remainingGB = false;
+					} else if(remainingCell[1] == 'GB') {
+						remainingGB = remainingCell[0];
+					} else {
+						remainingGB = remainingCell[0] / 1024;
+					}
+					
+					// Limit
+					var limitCell = $('td', tableRow).eq(2).text().split(' ');
+					if(limitCell[0] == 'N/A') {
+						limitGB = false;
+					} else {
+						limitGB = limitCell[0];
 					}
 					
 					// See if user has uncapped nights
@@ -224,10 +240,15 @@ function fetchDataUsage () {
 						planName: planName,
 						billingPeriodStartDate: billingPeriodStartDate,
 						billingPeriodEndDate: billingPeriodEndDate,
-						gigabyteLimit: gigabyteLimit,
-						gigabytesRemaining: gigabytesRemaining,
+						limitGB: limitGB,
+						usedGB: usedGB,
+						remainingGB: remainingGB,
 						uncappedNightsEnabled: uncappedNightsEnabled,
-						freeYouTubeEnabled: freeYouTubeEnabled
+						freeYouTubeEnabled: freeYouTubeEnabled,
+						
+						// Legacy (for compatibility)
+						gigabyteLimit: limitGB,
+						gigabytesRemaining: remainingGB
 					};
 					chrome.storage.local.set({ dataService: dataService }, function(){
 						createBrowserActionIcon();

--- a/extension/scripts/backgroundEventPage.js
+++ b/extension/scripts/backgroundEventPage.js
@@ -62,7 +62,10 @@ function createBrowserActionIcon () {
 						barColorImage = images.barRed;
 						break;
 				}
-				var barWidth = Math.round(17 * u.dataUsedPercentage);
+				var barWidth = Math.round(17 * (u.dataLimit
+				  ? u.dataUsedPercentage
+				  : u.daysElapsedPercentage
+				));
 				context.drawImage(barColorImage, 1, 14, barWidth, 4);
 				
 				// Horizontal shadow - goes to the right of the percentage bar

--- a/extension/scripts/browserActionPopupPage.js
+++ b/extension/scripts/browserActionPopupPage.js
@@ -13,6 +13,9 @@ function displayUsageInfo () {
 		// Plan name -- hide "& Snap Plus" if it's there because it makes the plan name rather long
 		$('#planName a').text(str_replace('& Snap Plus', '', u.planName));
 		
+		// Unlimited plan? Hide the irrelevant stuff
+		$('.unlimited-hide').css('display', 'none');
+		
 		// Normal data
 		$('#dataLimit').text(gbFormat(u.dataLimit));
 		$('#dataUsed').text(gbFormat(u.dataUsed));

--- a/extension/scripts/browserActionPopupPage.js
+++ b/extension/scripts/browserActionPopupPage.js
@@ -13,13 +13,13 @@ function displayUsageInfo () {
 		// Plan name -- hide "& Snap Plus" if it's there because it makes the plan name rather long
 		$('#planName a').text(str_replace('& Snap Plus', '', u.planName));
 		
-		// Unlimited plan? Hide the irrelevant stuff
-		$('.unlimited-hide').css('display', 'none');
-		
 		// Normal data
-		$('#dataLimit').text(gbFormat(u.dataLimit));
+		//$('#dataLimit').text(gbFormat(u.dataLimit));
 		$('#dataUsed').text(gbFormat(u.dataUsed));
-		$('#dataRemaining').text(gbFormat(u.dataRemaining));
+		$('#dataRemaining').html(u.dataLimit
+		  ? gbFormat(u.dataRemaining)
+		  : '&#8734;'
+		);
 		
 		// Offpeak data
 		if (dataService.uncappedNightsEnabled == true) {
@@ -45,13 +45,19 @@ function displayUsageInfo () {
 		
 		$('#monthlyEstimate').text(gbFormat(u.monthlyEstimate));
 		
-		$('#suggestedDailyUsage').html('<span class="tooltip">'+gbFormat(u.suggestedDailyUsage)+'</span>');
+		$('#suggestedDailyUsage').html(u.dataLimit
+		  ? '<span class="tooltip">'+gbFormat(u.suggestedDailyUsage)+'</span>'
+		  : '&#8734;'
+		);
 		var kbRemaining = u.dataRemaining * 1048576; // 1 GB = 1048576 KB
 		var kbPerSecond = kbRemaining / u.secondsRemaining;
 		$('#suggestedDailyUsage').attr('title', number_format(kbPerSecond, 1) + ' KB/s');
 		
 		// Percentage bar
-		$('#unfilledPortion').css('width', (100 - (u.dataUsedPercentage * 100)) + '%');
+		var percentageBar = u.dataLimit
+		  ? u.dataUsedPercentage * 100
+		  : u.daysElapsedPercentage * 100;
+		$('#unfilledPortion').css('width', (100 - percentageBar) + '%');
 		$('#percentageBar').removeClass();
 		$('#percentageBar').addClass(u.barColor);
 		var percentageBarPixelWidth = $('#percentageBar').width();

--- a/extension/scripts/commonFunctions.js
+++ b/extension/scripts/commonFunctions.js
@@ -1,10 +1,12 @@
 // Function to get usage info object, derived StorageArea's dataService object
 function getUsageInfoObject (dataService) {
 	var planName = dataService.planName;
-	var dataLimit = dataService.gigabyteLimit;
-	var dataUsed = dataService.gigabyteLimit - dataService.gigabytesRemaining;
-	var dataUsedPercentage = dataUsed / dataLimit;
-	var dataRemaining = dataService.gigabytesRemaining;
+	var dataLimit = dataService.limitGB;
+	var dataUsed = dataService.usedGB;
+	var dataUsedPercentage = dataLimit
+	  ? dataUsed / dataLimit
+	  : false;
+	var dataRemaining = dataService.remainingGB;
 	var billingPeriodStartTime = strtotime(fixBillingPeriodDate(dataService.billingPeriodStartDate));
 	var billingPeriodEndTime = strtotime(fixBillingPeriodDate(dataService.billingPeriodEndDate));
 	var daysInBillingPeriod = (billingPeriodEndTime - billingPeriodStartTime) / 86400; // (60 seconds * 60 minutes * 24 hours)
@@ -15,8 +17,18 @@ function getUsageInfoObject (dataService) {
 	var daysRemaining = secondsRemaining / 86400;
 	var averageDailyUsage = dataUsed / daysElapsed;
 	var monthlyEstimate = averageDailyUsage * daysInBillingPeriod;
-	var suggestedDailyUsage = Math.min(dataRemaining / daysRemaining, dataRemaining);
-	var barColor = monthlyEstimate > dataService.gigabyteLimit ? (dataUsed >= dataService.gigabyteLimit ? 'red' : 'orange') : 'green';
+	var suggestedDailyUsage = dataLimit
+	  ? Math.min(dataRemaining / daysRemaining, dataRemaining)
+	  : false;
+	  
+	// bar colour logic
+	if(dataLimit && dataUsed >= dataLimit) {
+		var barColor = 'red';
+	} else if(dataLimit && monthlyEstimate > dataLimit) {
+		var barColor = 'orange';
+	} else {
+		var barColor = 'green';
+	}
 	
 	return {
 		planName: planName,


### PR DESCRIPTION
As the extension was calculating the used GB from the Limit and Remaining, it didn't show any usage on Unlimited plans (as that would be 0 minus 0).

I've updated the extension to grab the Usage from Snap's page rather than calculating it, and also hide fields not relevant on Unlimited plans, as well as the percentage bar.

Haven't removed the bar from the icon canvas, as I felt it still served to illustrate that the extension is a usage meter.
